### PR TITLE
Avoid commits when no changes

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/Artifact.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Artifact.java
@@ -3,6 +3,7 @@ package com.redhat.labs.lodestar.model;
 import java.util.List;
 import java.util.Optional;
 
+import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 import javax.validation.constraints.NotBlank;
 
@@ -42,6 +43,7 @@ public class Artifact extends PanacheMongoEntityBase {
     @DiffIgnore
     private String created;
     @DiffIgnore
+    @JsonbProperty(value = "last_modified")
     private String modified;
 
     @NotBlank

--- a/src/main/java/com/redhat/labs/lodestar/service/ArtifactService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ArtifactService.java
@@ -140,14 +140,16 @@ public class ArtifactService {
 
             // modify artifacts in db
             String changeLog = modifyArtifactsByEngagementUuid(e.getKey(), e.getValue());
-            // create commit message
-            String commitMessage = new StringBuilder("Changed Engagement Artifacts\n").append(changeLog).toString();
-
-            // pull latest artifacts from db
-            List<Artifact> latest = Artifact.findAllByEngagementUuid(e.getKey());
-            // send to git to update file
-            updateArtifactsFile(e.getKey(), latest, authorEmail, authorName, Optional.ofNullable(commitMessage));
-
+            
+            if(changeLog.length() > 0) { //Empty string == no changes
+                // create commit message
+                String commitMessage = new StringBuilder(defaultCommitMessage).append(changeLog).toString();
+    
+                // pull latest artifacts from db
+                List<Artifact> latest = Artifact.findAllByEngagementUuid(e.getKey());
+                // send to git to update file
+                updateArtifactsFile(e.getKey(), latest, authorEmail, authorName, Optional.ofNullable(commitMessage));
+            }
         });
 
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,13 +30,16 @@ gitlab.api/mp-rest/url=${GITLAB_API_URL:https://acmegit.com}
 engagement.api/mp-rest/scope=javax.inject.Singleton
 engagement.api/mp-rest/url=${ENGAGEMENT_API_URL:http://git-api:8080}
 
+mp.openapi.extensions.smallrye.info.title=LodeStar Artifacts API
+quarkus.swagger-ui.theme=muted
+
 
 gitlab.personal.access.token=${GITLAB_TOKEN:t}
 
 # Application
 artifacts.file=${ARTIFACTS_FILE:artifacts.json}
 default.branch=${DEFAULT_BRANCH:master}
-default.commit.message=${DEFAULT_COMMIT_MESSAGE:updated artifacts list}
+default.commit.message=${DEFAULT_COMMIT_MESSAGE:Artifacts updated:\n}
 default.author.name=lodestar-artifacts-bot
 default.author.email=lodestar-artifacts-bot@bot.com
 default.page.size=${DEFAULT_PAGE_SIZE:20}


### PR DESCRIPTION
- jsonb field last_modified (modified wasn't serializing(?)
-  avoids commits when no changes were detected
- changes default message (will help dedup while updates continue to be made in backend as well)

